### PR TITLE
Get rid of inconsistently used $warning-color

### DIFF
--- a/source/js/components/Dashboard/Filter.jsx
+++ b/source/js/components/Dashboard/Filter.jsx
@@ -52,7 +52,7 @@ class Filter extends Component {
             className='FilterFinished-Button'
             onClick={ this.toggle }
           >
-            FERTIG
+            Fertig ✔
           </button>
         </footer>
       </section>

--- a/source/js/components/Dashboard/ResultView/ResultListItem.jsx
+++ b/source/js/components/Dashboard/ResultView/ResultListItem.jsx
@@ -28,7 +28,7 @@ class ResultListItem extends Component {
       'ResultListItem--selected': isSelected,
     });
 
-    let photoSrc = 'none';
+    const photoContainerStyle = { backgroundImage: 'none' };
     let photoInfoLink = null;
     if (item.get('foto')) {
       const hashString = item.get('foto')
@@ -42,7 +42,7 @@ class ResultListItem extends Component {
       const hash = md5(hashString);
       const hp1 = hash.substring(0, 1);
       const hp2 = hash.substring(0, 2);
-      photoSrc = `url('https://upload.wikimedia.org/wikipedia/commons/thumb/${ hp1 }/${ hp2 }/${ photoLinkString }/256px-${ photoLinkString }')`;
+      photoContainerStyle.backgroundImage = `url('https://upload.wikimedia.org/wikipedia/commons/thumb/${ hp1 }/${ hp2 }/${ photoLinkString }/256px-${ photoLinkString }')`;
 
       photoInfoLink = (
         <a
@@ -54,6 +54,14 @@ class ResultListItem extends Component {
           <span>Informationen zum Foto</span>
         </a>
       );
+    }
+
+    // parse hex categoryColor, make 50% transparent for background in PhotoContainer
+    if (categoryColor && categoryColor.match(/^#[0-9A-F]{6}$/i)) {
+      const r = parseInt(categoryColor.substring(1, 3), 16);
+      const g = parseInt(categoryColor.substring(3, 5), 16);
+      const b = parseInt(categoryColor.substring(5, 7), 16);
+      photoContainerStyle.backgroundColor = `rgba(${ r }, ${ g }, ${ b }, 0.5)`;
     }
 
     const locationInfo = item.get('adresse');
@@ -97,7 +105,7 @@ class ResultListItem extends Component {
       >
         <div
           className='PhotoContainer'
-          style={ { 'backgroundImage': photoSrc } }
+          style={ photoContainerStyle }
         >
           <a
             href={ item.get('uploadLink') }

--- a/source/scss/base/_config.scss
+++ b/source/scss/base/_config.scss
@@ -6,7 +6,6 @@ $primary-color-contrast: white; //the color for text on the primary color
 $secondary-color: rgb(57, 57, 114);
 $secondary-color-contrast: white;
 
-$warning-color: rgb(232, 101, 104);
 $unaviable-color: rgb(199, 73, 78);
 
 $text-color: #24224c;

--- a/source/scss/components/_filters.scss
+++ b/source/scss/components/_filters.scss
@@ -37,10 +37,11 @@
       display:block;
       width:100%;
       font-size: 2em;
-      color:white;
+      color: $primary-color;
       padding:.5em 0;
-      background-color: $warning-color;
+      background-color: $primary-color-contrast;
       font-weight:bold;
+      text-transform: uppercase;
     }
 
     @include md {

--- a/source/scss/components/_resultlist.scss
+++ b/source/scss/components/_resultlist.scss
@@ -34,7 +34,7 @@
   }
 
   &.ResultListItem--selected {
-    background-color:lighten($warning-color, 20%);
+    background-color:lighten($primary-color, 60%);
   }
 
   .PhotoContainer {

--- a/source/scss/components/_resultlist.scss
+++ b/source/scss/components/_resultlist.scss
@@ -42,7 +42,7 @@
     flex-shrink: 0;
     position:relative;
     margin-right:1em;
-    background: $warning-color;
+    background: rgba(0,0,0,.2);
     background-size:cover;
     background-repeat: no-repeat;
     background-position: center center;

--- a/source/scss/components/_searchbar.scss
+++ b/source/scss/components/_searchbar.scss
@@ -52,7 +52,7 @@
     }
 
     .ViennaWarning {
-      background-color: $warning-color;
+      background-color: $unaviable-color;
       color: white;
       font-size:.8em;
     }


### PR DESCRIPTION
The red $warning-color is used for various/four purposes. I propose to replace all usages by a more adequate color:
- Filter: submit button in contrast primary color
- SearchBar: change red
- ResultListItem: light primary color as background
- ResultListItem: transparent category color as bg

See also https://de.wikipedia.org/wiki/Wikipedia_Diskussion:WikiDaheim#Mein_Feedback_vom_2017-08-29