### PR TITLE
Adding pointer-cursor in search-bar suggestions

### DIFF
--- a/source/scss/components/_searchbar.scss
+++ b/source/scss/components/_searchbar.scss
@@ -34,6 +34,7 @@
   .SearchBar-Suggestions {
     background-color: $secondary-color;
     color: $secondary-color-contrast;
+    cursor: pointer;
     font-size:1.6em;
     position: fixed;
     overflow: auto;


### PR DESCRIPTION
When user hovers over the search-bar suggestions, the presented list doesn't seem to be clickable. Therefore, this change shows the cursor: pointer in the search-bar suggestions.