### PR TITLE
feat(SearchBar): add accesskey 'f'

### DIFF
--- a/source/js/components/Dashboard/SearchBar.jsx
+++ b/source/js/components/Dashboard/SearchBar.jsx
@@ -79,7 +79,7 @@ class SearchBar extends Component {
       <section className='SearchBar'>
         <div className='SearchBar-Bar'>
           <Autocomplete
-            inputProps={ { placeholder: 'Gemeinde hier suchen...' } }
+            inputProps={ { placeholder: 'Gemeinde hier suchen...', accessKey: 'f' } }
             getItemValue={ (item) => item.place_name }
             items={ searchData.toJS() }
             renderItem={ renderItem }


### PR DESCRIPTION
Analogue to https://en.wikipedia.org/wiki/Wikipedia:Keyboard_shortcuts, 'f' moves the cursor to the search box.