### PR TITLE
style: disable font ligatures

### DIFF
--- a/source/scss/base/_app.scss
+++ b/source/scss/base/_app.scss
@@ -1,5 +1,6 @@
 html {
   font-family: $main-font;
+  font-variant-ligatures: none;
 
   font-size:12px;
 

--- a/source/scss/components/_map.scss
+++ b/source/scss/components/_map.scss
@@ -64,6 +64,7 @@
   color: $primary-color-contrast;
   background: transparent !important;
   font-family: $main-font;
+  font-variant-ligatures: none;
   padding: .5em .5em !important;
   border-radius:none !important;
   text-align: center;


### PR DESCRIPTION
Font ligatures are ugly for monospaced font (Firefox 67.0.4)

![2019-07-02_19-23](https://user-images.githubusercontent.com/782446/60533112-18e89500-9cff-11e9-8cba-001f5310fd57.png)
